### PR TITLE
Index Page link to Hosted MMS 

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,11 +92,14 @@ img.two {
         </div>
 
         <div class="col-lg-6">
+          <h4><a href="https://github.com/Open-MBEE">OpenMBEE Development Projects</a></h4>
+          <p>Other projects, such as tool-specific Model Development Kits for <a target="_blank" href="https://www.wolfram.com/mathematica/">Mathematica</a>, <a target="_blank" href="https://www.mathworks.com/products/matlab.html">MATLAB</a>, <a target="_blank" href="http://www.phoenix-int.com/modelcenter/integrate.php">ModelCenter</a>, and a <a target="_blank" href="https://github.com/Open-MBEE/mdk-expression">AsciiMathML based expression editor</a> can be found in the organization's GitHub page.</p>
+
           <h4><a href="https://github.com/Open-MBEE/TMT-SysML-Model">Thirty Meter Telescope SysML Model</a></h4>
           <p>TMT is currently being developed by the <a target="_blank" href="http://www.tmt.org/">TMT Observatory Corporation</a>. The TMT SysML model provides an industrial scale application of OpenMBEE and system-level behavior simulation. The main objective for the TMT related analysis is to provide state-dependent power roll-ups for different operational scenarios and demonstrate that requirements are satisfied by the design as well as mass roll-ups and duration analysis of the operational use cases. The model is built with an approach to model-based systems analysis with SysML that is both rigorous and automated. The approach’s rigor is established with a modeling method that is an extension of <a target="_blank" href="http://www.incose.org/">INCOSE</a>’s Object Oriented Systems Engineering Method (OOSEM).</p>
 
-          <h4><a href="https://github.com/Open-MBEE">Other OpenMBEE Projects</a></h4>
-          <p>Other projects, such as tool-specific Model Development Kits for <a target="_blank" href="https://www.wolfram.com/mathematica/">Mathematica</a>, <a target="_blank" href="https://www.mathworks.com/products/matlab.html">MATLAB</a>, <a target="_blank" href="http://www.phoenix-int.com/modelcenter/integrate.php">ModelCenter</a>, and a <a target="_blank" href="https://github.com/Open-MBEE/mdk-expression">AsciiMathML based expression editor</a> can be found in the organization's GitHub page.</p>
+          <h4><a href="https://mms.openmbee.org/">Hosted Models</a></h4>
+          <p>OpenMBEE hosts a number of model development projects in support of evolving Model Based Engineering standards, such as <a target="_blank" href="http://www.omgwiki.org/OMGSysML/doku.php?id=sysml-roadmap:systems_engineering_concept_model_workgroup">SECM</a> and <a target="_blank" href="http://www.omgsysml.org">SysML 1.X</a>. Those interested in contributing to these efforts should contact the respective project owners for access credentials.</p>       
         </div>
       </div>
 


### PR DESCRIPTION
Modify index page to link to the hosted OpenMBEE instance for better visibility and more straightforward access.