### PR TITLE
#58 - remove broken social media pages from navbar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -42,19 +42,12 @@
           </a>
           <div class="dropdown-menu">
             <a class="dropdown-item" href="code-of-conduct.html">Code of Conduct</a>
-            <a class="dropdown-item" href="governance.html">Governance</a>
             <a class="dropdown-item" href="leadership.html">Leadership</a>
-            <a class="dropdown-item" href="licenses.html">Licenses</a>
             <div role="separator" class="dropdown-divider"></div>
-            <a class="dropdown-item" href="https://facebook.com/openmbee/" target="_blank">Facebook</a>
             <a class="dropdown-item" href="calendar.html">Community Calendar</a>
             <a class="dropdown-item" href="https://groups.google.com/forum/#!forum/openmbee" target="_blank">Google Group</a>
             <a class="dropdown-item" href="https://www.omgwiki.org/MBSE/doku.php?id=mbse:ecosystems" target="_blank">INCOSE</a>
-            <a class="dropdown-item" href="https://www.linkedin.com/in/open-mbee-491a851a3/" target="_blank">LinkedIn</a>
             <a class="dropdown-item" href="https://openmbee.slack.com" target="_blank">Slack</a>
-            <a class="dropdown-item" href="https://twitter.com/openmbee" target="_blank">Twitter</a>
-            <a class="dropdown-item" href="https://www.instagram.com/openmbee" target="_blank">Instagram</a>
-            <a class="dropdown-item" href="https://medium.com/@openmbee" target="_blank">Medium</a>
             <a class="dropdown-item" href="https://www.youtube.com/channel/UCC4Ucy6P86ozz3pT01H7fmA" target="_blank">YouTube</a>
             <!-- <div role="separator" class="dropdown-divider"></div>
             <a class="dropdown-item" href="contribute.html" role="button">Contribute</a> -->


### PR DESCRIPTION
Removed the following from NavBar:
- Governance
- Licenses
- Facebook
- LinkedIn
- Twitter
- Instagram
- Medium