### PR TITLE
dev: redirected navbar links to github wiki pages

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -16,12 +16,12 @@
           <div class="dropdown-menu">
             <a class="dropdown-item" href="about.html">About Us</a>
             <a class="dropdown-item" href="impacts.html">Impacts</a>
-            <a class="dropdown-item" href="publications.html">Publications</a>
-            <a class="dropdown-item" href="numfocus.html">NumFOCUS Project</a>
+            <a class="dropdown-item" href="https://github.com/Open-MBEE/open-mbee.github.io/wiki/Publications">Publications</a>
           </div>
         </li>
-        <li class="nav-item"><a class="nav-link" href="contribute.html" role="button">Contribute</a></li>
-        <li class="nav-item"><a class="nav-link" href="participate.html" role="button">Participate</a></li>
+        <li class="nav-item"><a class="nav-link" href="numfocus.html" role="button">NumFOCUS Project</a></li>
+        <li class="nav-item"><a class="nav-link" href="https://github.com/Open-MBEE/open-mbee.github.io/wiki/Contribute" role="button">Contribute</a></li>
+        <li class="nav-item"><a class="nav-link" href="https://github.com/Open-MBEE/open-mbee.github.io/wiki/Participate" role="button">Participate</a></li>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true"
              aria-expanded="false">Projects <span class="caret"></span>
@@ -66,7 +66,7 @@
              aria-expanded="false">Events <span class="caret"></span>
           </a>
           <div class="dropdown-menu">
-            <a class="dropdown-item" href="events.html">All Events</a>
+            <a class="dropdown-item" href="https://openmbee.atlassian.net/wiki/spaces/OPENMBEE/pages/542998531/Events">All Events</a>
             <div role="separator" class="dropdown-divider"></div>
             <a class="dropdown-item" href="https://openmbee.atlassian.net/l/cp/1mTWaHHZ" target="_blank">Hackathon Workshop - INCOSE IS 2023</a>
           </div>


### PR DESCRIPTION
Created github wiki pages for publications, contribute, participate, events links in website, and moved numFocus link from a dropdown to the main taskbar

Modified/added git wiki pages:
- https://github.com/Open-MBEE/open-mbee.github.io/wiki (modified)
- https://github.com/Open-MBEE/open-mbee.github.io/wiki/Publications (as a landing point for the website)
- https://github.com/Open-MBEE/open-mbee.github.io/wiki/OpenMBEE-Publications
- https://github.com/Open-MBEE/open-mbee.github.io/wiki/Community-Publications
- https://github.com/Open-MBEE/open-mbee.github.io/wiki/Contribute
- https://github.com/Open-MBEE/open-mbee.github.io/wiki/Participate